### PR TITLE
增加安卓和MacOS运行脚本的教程

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,13 @@
 
 ### 方法一：本地安装Node.js，下载本库脚本
 
-  - 教程请见：[EvineDeng/jd-base](https://github.com/EvineDeng/jd-base)
+  - 教程请见：[EvineDeng/jd-base](https://github.com/EvineDeng/jd-base)，适用于以下系统：
+
+    1. Armbian/OpenWrt/Debian/Ubuntu/CentOS/Fedora/RedHat等Linux系统
+
+    2. Android
+
+    3. MacOS
 
 ### 方法二：云服务器、腾讯云函数等等
 
@@ -65,7 +71,7 @@
  
 ### 方法三：Docker（NAS或VPS用户）
 
- - 可以精确控制任务运行时间，有三种办法：[docker办法一](https://github.com/lxk0301/jd_scripts/tree/master/docker)、[docker办法二（和本地安装Node.js有点类似）](https://github.com/EvineDeng/jd-base)、[docker办法三](https://github.com/chinnkarahoi/jd-scripts-docker)
+ - 可以精确控制任务运行时间，有三种办法：[docker办法一](https://github.com/lxk0301/jd_scripts/tree/master/docker)、[docker办法二（和本地安装Node.js类似）](https://github.com/EvineDeng/jd-base)、[docker办法三](https://github.com/chinnkarahoi/jd-scripts-docker)
  - [环境变量](https://github.com/lxk0301/jd_scripts/blob/master/githubAction.md#%E4%B8%8B%E6%96%B9%E6%8F%90%E4%BE%9B%E4%BD%BF%E7%94%A8%E5%88%B0%E7%9A%84-secrets%E5%85%A8%E9%9B%86%E5%90%88)
  
 #### 注：以上三种运行机制都是Node.js，故您需仔细阅读下面几点


### PR DESCRIPTION
增加安卓和MacOS运行脚本的教程，适用系统包括：

    1. Armbian/OpenWrt/Debian/Ubuntu/CentOS/Fedora/RedHat等Linux系统

    2. Android

    3. MacOS