### PR TITLE
因为签到文件下载目录调整，request依赖的安装路径也需要调整

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN git clone https://github.com/lxk0301/jd_scripts /scripts \
         && cd /scripts \
         && mkdir logs \
         && npm install \
-        && cd ~ \
+        && cd /tmp \
         && npm install request
 
 ENV CRONTAB_LIST_FILE crontab_list_ts.sh

--- a/docker/crontab_list.sh
+++ b/docker/crontab_list.sh
@@ -1,6 +1,7 @@
 0 */1 * * * git -C /scripts/ pull >> /scripts/logs/pull.log 2>&1
 2 */1 * * * crontab /scripts/docker/${CRONTAB_LIST_FILE}
 3 */1 * * * npm install --prefix /scripts >> /scripts/logs/npm_install.log 2>&1
+4 */1 * * * npm install request --prefix /tmp >> /scripts/logs/npm_install_request.log 2>&1
 # 每3天的23:50分清理一次日志
 50 23 */3 * * rm -rf /scripts/logs/*.log
 
@@ -44,7 +45,7 @@
 # 取关京东店铺商品
 55 23 * * * node /scripts/jd_unsubscribe.js >> /scripts/logs/jd_unsubscribe.log 2>&1
 # 京豆变动通知
-0 2 * * * node /scripts/jd_bean_change.js >> /scripts/logs/jd_bean_change.log 2>&1
+0 10 * * * node /scripts/jd_bean_change.js >> /scripts/logs/jd_bean_change.log 2>&1
 # 京东抽奖机
 11 1 * * * node /scripts/jd_lotteryMachine.js >> /scripts/logs/jd_lotteryMachine.log 2>&1
 # 京东排行榜

--- a/docker/crontab_list_ts.sh
+++ b/docker/crontab_list_ts.sh
@@ -1,6 +1,7 @@
 0 */1 * * * git -C /scripts/ pull |ts >> /scripts/logs/pull.log 2>&1
 2 */1 * * * crontab /scripts/docker/${CRONTAB_LIST_FILE}
 3 */1 * * * npm install --prefix /scripts |ts >> /scripts/logs/npm_install.log 2>&1
+4 */1 * * * npm install request --prefix /tmp |ts >> /scripts/logs/npm_install_request.log 2>&1
 # 每3天的23:50分清理一次日志
 50 23 */3 * * rm -rf /scripts/logs/*.log
 

--- a/docker/crontab_list_ts.sh
+++ b/docker/crontab_list_ts.sh
@@ -45,7 +45,7 @@
 # 取关京东店铺商品
 55 23 * * * node /scripts/jd_unsubscribe.js |ts >> /scripts/logs/jd_unsubscribe.log 2>&1
 # 京豆变动通知
-0 2 * * * node /scripts/jd_bean_change.js |ts >> /scripts/logs/jd_bean_change.log 2>&1
+0 10 * * * node /scripts/jd_bean_change.js |ts >> /scripts/logs/jd_bean_change.log 2>&1
 # 京东抽奖机
 11 1 * * * node /scripts/jd_lotteryMachine.js |ts >> /scripts/logs/jd_lotteryMachine.log 2>&1
 # 京东排行榜


### PR DESCRIPTION
- 因为签到文件下载目录调整，request依赖的安装路径也需要调整，否则签到会报 `request` 依赖错误
- `contab_list*.sh`  增加一条定时任务可以让使用默认定时任务的不需要更新镜像, 
   > 如果使用 自定义任务的 需要更新镜像 或者 手动执行 `docker exec -it 容器名 /bin/sh -c 'npm install request --prefix /tmp' ` 在或者在自定义任务里面增加 一条定时任务