### PR TITLE
GitHub Action 部署到腾讯云函数完善

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,25 @@
 'use strict';
 exports.main_handler = async (event, context, callback) => {
-    for (const v of event["Message"].split("\r\n")) {
-        console.log(v);
-        var request = require('request');
-        request('https://gitee.com/lxk0301/jd_scripts/raw/master/'+v+'.js', function (error, response, body) {
+  try {
+      //如果想在一个定时触发器里面执行多个js文件需要在定时触发器的【附加信息】里面填写对应的名称，用 & 链接
+      //例如我想一个定时触发器里执行jd_speed.js和jd_bean_change.js，在定时触发器的【附加信息】里面就填写 jd_speed&jd_bean_change
+      for (const v of event["Message"].split("&")) {
+          console.log(v);
+          var request = require('request');
+          //1.执行自己上传的js文件
+          //require('./'+v+'.js')
+
+          //2.执行国内gitee远端js文件如果部署，在国内节点，选择1或2的方式
+          //request('https://gitee.com/lxk0301/jd_scripts/raw/master/'+v+'.js', function (error, response, body) {
+          //    eval(response.body)
+          //})
+
+          //3.执行github远端的js文件
+          request('https://raw.githubusercontent.com/lxk0301/jd_scripts/master/'+v+'.js', function (error, response, body) {
             eval(response.body)
-        })
-    }
+          })  
+      }
+   } catch (e) {
+    console.error(e)
+   }
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,10 @@
 'use strict';
 exports.main_handler = async (event, context, callback) => {
-  require('./jd_xtg.js') //这里写你想要的脚本
-  require('./jd_fruit.js') //这里写你想要的脚本
+    for (const v of event["Message"].split("\r\n")) {
+        console.log(v);
+        var request = require('request');
+        request('https://gitee.com/lxk0301/jd_scripts/raw/master/'+v+'.js', function (error, response, body) {
+            eval(response.body)
+        })
+    }
 }

--- a/serverless.yml
+++ b/serverless.yml
@@ -18,10 +18,16 @@ inputs:
   events: # 触发器
     - timer: # 定时触发器
         parameters:
-          # name: timer # 触发器名称，默认timer-${name}-${stage}
+          name: jd_bean_sign # 触发器名称
           cronExpression: "0 0 0 */1 * * *" # 每天零点执行一次
           enable: true
-          argument: argument # 额外的参数
+          argument: jd_bean_sign # 额外的参数
+    - timer: # 定时触发器
+        parameters:
+          name: jd_blueCoin
+          cronExpression: "0 0 0 */1 * * *" # 每天零点执行一次
+          enable: true
+          argument: jd_blueCoin,jd_club_lottery # 额外的参数
   environment: #  环境变量
     variables: #  环境变量对象
       AAA: BBB # 不要删除，用来格式化对齐追加的变量的

--- a/serverless.yml
+++ b/serverless.yml
@@ -27,7 +27,7 @@ inputs:
           name: jd_blueCoin
           cronExpression: "0 0 0 */1 * * *" # 每天零点执行一次
           enable: true
-          argument: [jd_blueCoin,jd_club_lottery] # 额外的参数
+          argument: jd_blueCoin jd_club_lottery,JD2&JD3|JD4 # 额外的参数
   environment: #  环境变量
     variables: #  环境变量对象
       AAA: BBB # 不要删除，用来格式化对齐追加的变量的

--- a/serverless.yml
+++ b/serverless.yml
@@ -16,18 +16,132 @@ inputs:
   memorySize: 128 # 内存大小，单位MB
   timeout: 900 # 超时时间，单位秒
   events: # 触发器
-    - timer: # 定时触发器
+    - timer: # 签到
         parameters:
-          name: jd_bean_sign # 触发器名称
-          cronExpression: "0 0 0 */1 * * *" # 每天零点执行一次
+          name: jd_bean_sign
+          cronExpression: "0 0 0,12,18 * * *"
           enable: true
-          argument: jd_bean_sign # 额外的参数
-    - timer: # 定时触发器
+          argument: jd_bean_sign
+    - timer: # 京小超兑换奖品
         parameters:
           name: jd_blueCoin
-          cronExpression: "0 0 0 */1 * * *" # 每天零点执行一次
+          cronExpression: "0 0 0 * * *"
           enable: true
-          argument: jd_blueCoin|jd_club_lottery|JD2\nJD3\nJD4 # 额外的参数
+          argument: jd_blueCoin
+    - timer: # 摇京豆
+        parameters:
+          name: jd_club_lottery
+          cronExpression: "0 0 0 * * *"
+          enable: true
+          argument: jd_club_lottery
+    - timer: # 东东农场
+        parameters:
+          name: jd_fruit
+          cronExpression: "0 5 6-18/6 * * *"
+          enable: true
+          argument: jd_fruit
+    - timer: # 宠汪汪
+        parameters:
+          name: jd_joy
+          cronExpression: "0 15 */2 * * *"
+          enable: true
+          argument: jd_joy
+    - timer: # 宠汪汪喂食
+        parameters:
+          name: jd_joy_feedPets
+          cronExpression: "0 15 */1 * * *"
+          enable: true
+          argument: jd_joy_feedPets
+    - timer: # 宠汪汪积分兑换奖品
+        parameters:
+          name: jd_joy_reward
+          cronExpression: "0 0 0-16/8 * * *"
+          enable: true
+          argument: jd_joy_reward
+    - timer: # 宠汪汪偷好友积分与狗
+        parameters:
+          name: jd_joy_steal
+          cronExpression: "0 0 0,6 * * *"
+          enable: true
+          argument: jd_joy_steal
+    - timer: # 摇钱树
+        parameters:
+          name: jd_moneyTree
+          cronExpression: "0 0 */2 * * *"
+          enable: true
+          argument: jd_moneyTree
+    - timer: # 东东萌宠
+        parameters:
+          name: jd_pet
+          cronExpression: "0 5 6-18/6 * * *"
+          enable: true
+          argument: jd_pet
+    - timer: # 京东种豆得豆
+        parameters:
+          name: jd_plantBean
+          cronExpression: "0 0 7-22/1 * * *"
+          enable: true
+          argument: jd_plantBean
+    - timer: # 京东全民开红包
+        parameters:
+          name: jd_redPacket
+          cronExpression: "0 1 1 * * *"
+          enable: true
+          argument: jd_redPacket
+    - timer: # 进店领豆
+        parameters:
+          name: jd_shop
+          cronExpression: "0 10 0 * * *"
+          enable: true
+          argument: jd_shop
+    - timer: # 京东天天加速
+        parameters:
+          name: jd_speed
+          cronExpression: "0 8 */3 * * *"
+          enable: true
+          argument: jd_speed
+    - timer: # 东东超市
+        parameters:
+          name: jd_superMarket
+          cronExpression: "0 11 1-23/5 * * *"
+          enable: true
+          argument: jd_superMarket
+    - timer: # 取关京东店铺商品
+        parameters:
+          name: jd_unsubscribe
+          cronExpression: "0 55 23 * * *"
+          enable: true
+          argument: jd_unsubscribe
+    - timer: # 京豆变动通知
+        parameters:
+          name: jd_bean_change
+          cronExpression: "0 0 10 * * *"
+          enable: true
+          argument: jd_bean_change
+    - timer: # 京东抽奖机
+        parameters:
+          name: jd_lotteryMachine
+          cronExpression: "0 11 1 * * *"
+          enable: true
+          argument: jd_lotteryMachine
+    - timer: # 京东排行榜
+        parameters:
+          name: jd_rankingList
+          cronExpression: "0 11 9 * * *"
+          enable: true
+          argument: jd_rankingList
+    - timer: # 天天提鹅
+        parameters:
+          name: jd_daily_egg
+          cronExpression: "0 18 */3 * * *"
+          enable: true
+          argument: jd_daily_egg
+    - timer: # 金融养猪
+        parameters:
+          name: jd_pigPet
+          cronExpression: "0 12 * * * *"
+          enable: true
+          argument: jd_pigPet
   environment: #  环境变量
     variables: #  环境变量对象
       AAA: BBB # 不要删除，用来格式化对齐追加的变量的

--- a/serverless.yml
+++ b/serverless.yml
@@ -16,84 +16,48 @@ inputs:
   memorySize: 128 # 内存大小，单位MB
   timeout: 900 # 超时时间，单位秒
   events: # 触发器
-    - timer: # 签到
+    - timer: # 签到 # 摇京豆
         parameters:
-          name: jd_bean_sign
+          name: jd_bean_sign&jd_club_lottery
           cronExpression: "0 0 0,12,18 * * *"
           enable: true
-          argument: jd_bean_sign
+          argument: jd_bean_sign&jd_club_lottery
     - timer: # 京小超兑换奖品
         parameters:
           name: jd_blueCoin
           cronExpression: "0 0 0 * * *"
           enable: true
           argument: jd_blueCoin
-    - timer: # 摇京豆
+    - timer: # 东东农场# 东东萌宠
         parameters:
-          name: jd_club_lottery
-          cronExpression: "0 0 0 * * *"
-          enable: true
-          argument: jd_club_lottery
-    - timer: # 东东农场
-        parameters:
-          name: jd_fruit
+          name: jd_fruit&jd_pet
           cronExpression: "0 5 6-18/6 * * *"
           enable: true
-          argument: jd_fruit
-    - timer: # 宠汪汪
+          argument: jd_fruit&jd_pet
+    - timer: # 宠汪汪喂食# 宠汪汪# 摇钱树
         parameters:
-          name: jd_joy
-          cronExpression: "0 15 */2 * * *"
-          enable: true
-          argument: jd_joy
-    - timer: # 宠汪汪喂食
-        parameters:
-          name: jd_joy_feedPets
+          name: jd_joy_feedPets&jd_joy&jd_moneyTree
           cronExpression: "0 15 */1 * * *"
           enable: true
-          argument: jd_joy_feedPets
-    - timer: # 宠汪汪积分兑换奖品
+          argument: jd_joy_feedPets&jd_joy&jd_moneyTree
+    - timer: # 宠汪汪积分兑换奖品# 宠汪汪偷好友积分与狗
         parameters:
-          name: jd_joy_reward
+          name: jd_joy_reward&jd_joy_steal
           cronExpression: "0 0 0-16/8 * * *"
           enable: true
-          argument: jd_joy_reward
-    - timer: # 宠汪汪偷好友积分与狗
-        parameters:
-          name: jd_joy_steal
-          cronExpression: "0 0 0,6 * * *"
-          enable: true
-          argument: jd_joy_steal
-    - timer: # 摇钱树
-        parameters:
-          name: jd_moneyTree
-          cronExpression: "0 0 */2 * * *"
-          enable: true
-          argument: jd_moneyTree
-    - timer: # 东东萌宠
-        parameters:
-          name: jd_pet
-          cronExpression: "0 5 6-18/6 * * *"
-          enable: true
-          argument: jd_pet
+          argument: jd_joy_reward&jd_joy_steal
     - timer: # 京东种豆得豆
         parameters:
           name: jd_plantBean
           cronExpression: "0 0 7-22/1 * * *"
           enable: true
           argument: jd_plantBean
-    - timer: # 京东全民开红包
+    - timer: # 京东全民开红包 # 进店领豆 # 取关京东店铺商品# 京东抽奖机
         parameters:
-          name: jd_redPacket
-          cronExpression: "0 1 1 * * *"
-          enable: true
-          argument: jd_redPacket
-    - timer: # 进店领豆
-        parameters:
-          name: jd_shop
+          name: jd_redPacket&jd_shop&jd_unsubscribe&jd_lotteryMachine
           cronExpression: "0 10 0 * * *"
           enable: true
-          argument: jd_shop
+          argument: jd_redPacket&jd_shop&jd_unsubscribe&jd_lotteryMachine
     - timer: # 京东天天加速
         parameters:
           name: jd_speed
@@ -106,42 +70,18 @@ inputs:
           cronExpression: "0 11 1-23/5 * * *"
           enable: true
           argument: jd_superMarket
-    - timer: # 取关京东店铺商品
-        parameters:
-          name: jd_unsubscribe
-          cronExpression: "0 55 23 * * *"
-          enable: true
-          argument: jd_unsubscribe
-    - timer: # 京豆变动通知
+    - timer: # 京豆变动通知 # 京东排行榜
         parameters:
           name: jd_bean_change
           cronExpression: "0 0 10 * * *"
           enable: true
-          argument: jd_bean_change
-    - timer: # 京东抽奖机
+          argument: jd_bean_change&jd_rankingList
+    - timer: # 金融养猪# 天天提鹅
         parameters:
-          name: jd_lotteryMachine
-          cronExpression: "0 11 1 * * *"
-          enable: true
-          argument: jd_lotteryMachine
-    - timer: # 京东排行榜
-        parameters:
-          name: jd_rankingList
-          cronExpression: "0 11 9 * * *"
-          enable: true
-          argument: jd_rankingList
-    - timer: # 天天提鹅
-        parameters:
-          name: jd_daily_egg
-          cronExpression: "0 18 */3 * * *"
-          enable: true
-          argument: jd_daily_egg
-    - timer: # 金融养猪
-        parameters:
-          name: jd_pigPet
+          name: jd_pigPet&jd_daily_egg
           cronExpression: "0 12 * * * *"
           enable: true
-          argument: jd_pigPet
+          argument: jd_pigPet&jd_daily_egg
   environment: #  环境变量
     variables: #  环境变量对象
       AAA: BBB # 不要删除，用来格式化对齐追加的变量的

--- a/serverless.yml
+++ b/serverless.yml
@@ -27,9 +27,7 @@ inputs:
           name: jd_blueCoin
           cronExpression: "0 0 0 */1 * * *" # 每天零点执行一次
           enable: true
-          argument: 
-            - jd_blueCoin
-            - jd_club_lottery # 额外的参数
+          argument: [jd_blueCoin,jd_club_lottery] # 额外的参数
   environment: #  环境变量
     variables: #  环境变量对象
       AAA: BBB # 不要删除，用来格式化对齐追加的变量的

--- a/serverless.yml
+++ b/serverless.yml
@@ -27,7 +27,9 @@ inputs:
           name: jd_blueCoin
           cronExpression: "0 0 0 */1 * * *" # 每天零点执行一次
           enable: true
-          argument: jd_blueCoin,jd_club_lottery # 额外的参数
+          argument: 
+            - jd_blueCoin
+            - jd_club_lottery # 额外的参数
   environment: #  环境变量
     variables: #  环境变量对象
       AAA: BBB # 不要删除，用来格式化对齐追加的变量的

--- a/serverless.yml
+++ b/serverless.yml
@@ -27,7 +27,7 @@ inputs:
           name: jd_blueCoin
           cronExpression: "0 0 0 */1 * * *" # 每天零点执行一次
           enable: true
-          argument: jd_blueCoin jd_club_lottery,JD2&JD3|JD4 # 额外的参数
+          argument: jd_blueCoin|jd_club_lottery|JD2\nJD3\nJD4 # 额外的参数
   environment: #  环境变量
     variables: #  环境变量对象
       AAA: BBB # 不要删除，用来格式化对齐追加的变量的

--- a/serverless.yml
+++ b/serverless.yml
@@ -58,12 +58,6 @@ inputs:
           cronExpression: "0 8 */3 * * * *"
           enable: true
           argument: jd_speed
-    - timer: # 京东天天加速1
-        parameters:
-          name: jd_speed1
-          cronExpression: "0 8 */3 * * * *"
-          enable: true
-          argument: jd_speed
     - timer: # 东东超市
         parameters:
           name: jd_superMarket

--- a/serverless.yml
+++ b/serverless.yml
@@ -58,6 +58,12 @@ inputs:
           cronExpression: "0 8 */3 * * * *"
           enable: true
           argument: jd_speed
+    - timer: # 京东天天加速1
+        parameters:
+          name: jd_speed1
+          cronExpression: "0 8 */3 * * * *"
+          enable: true
+          argument: jd_speed
     - timer: # 东东超市
         parameters:
           name: jd_superMarket

--- a/serverless.yml
+++ b/serverless.yml
@@ -18,7 +18,7 @@ inputs:
   events: # 触发器
     - timer: # 签到 # 摇京豆
         parameters:
-          name: jd_bean_sign&jd_club_lottery
+          name: jd_bean_sign_jd_club_lottery
           cronExpression: "0 0 0,12,18 * * *"
           enable: true
           argument: jd_bean_sign&jd_club_lottery
@@ -30,31 +30,25 @@ inputs:
           argument: jd_blueCoin
     - timer: # 东东农场# 东东萌宠
         parameters:
-          name: jd_fruit&jd_pet
+          name: jd_fruit_jd_pet
           cronExpression: "0 5 6-18/6 * * *"
           enable: true
           argument: jd_fruit&jd_pet
-    - timer: # 宠汪汪喂食# 宠汪汪# 摇钱树
+    - timer: # 宠汪汪喂食# 宠汪汪# 摇钱树# 京东种豆得豆
         parameters:
-          name: jd_joy_feedPets&jd_joy&jd_moneyTree
+          name: jd_joy_feedPets_jd_joy_jd_moneyTree_jd_plantBean
           cronExpression: "0 15 */1 * * *"
           enable: true
-          argument: jd_joy_feedPets&jd_joy&jd_moneyTree
+          argument: jd_joy_feedPets&jd_joy&jd_moneyTree&jd_plantBean
     - timer: # 宠汪汪积分兑换奖品# 宠汪汪偷好友积分与狗
         parameters:
-          name: jd_joy_reward&jd_joy_steal
+          name: jd_joy_reward_jd_joy_steal
           cronExpression: "0 0 0-16/8 * * *"
           enable: true
           argument: jd_joy_reward&jd_joy_steal
-    - timer: # 京东种豆得豆
-        parameters:
-          name: jd_plantBean
-          cronExpression: "0 0 7-22/1 * * *"
-          enable: true
-          argument: jd_plantBean
     - timer: # 京东全民开红包 # 进店领豆 # 取关京东店铺商品# 京东抽奖机
         parameters:
-          name: jd_redPacket&jd_shop&jd_unsubscribe&jd_lotteryMachine
+          name: jd_redPacket_jd_shop_jd_unsubscribe_jd_lotteryMachine
           cronExpression: "0 10 0 * * *"
           enable: true
           argument: jd_redPacket&jd_shop&jd_unsubscribe&jd_lotteryMachine
@@ -78,7 +72,7 @@ inputs:
           argument: jd_bean_change&jd_rankingList
     - timer: # 金融养猪# 天天提鹅
         parameters:
-          name: jd_pigPet&jd_daily_egg
+          name: jd_pigPet_jd_daily_egg
           cronExpression: "0 12 * * * *"
           enable: true
           argument: jd_pigPet&jd_daily_egg

--- a/serverless.yml
+++ b/serverless.yml
@@ -19,61 +19,61 @@ inputs:
     - timer: # 签到 # 摇京豆
         parameters:
           name: jd_bean_sign_jd_club_lottery
-          cronExpression: "0 0 0,12,18 * * *"
+          cronExpression: "0 0 0,12,18 * * * *"
           enable: true
           argument: jd_bean_sign&jd_club_lottery
     - timer: # 京小超兑换奖品
         parameters:
           name: jd_blueCoin
-          cronExpression: "0 0 0 * * *"
+          cronExpression: "0 0 0 * * * *"
           enable: true
           argument: jd_blueCoin
     - timer: # 东东农场# 东东萌宠
         parameters:
           name: jd_fruit_jd_pet
-          cronExpression: "0 5 6-18/6 * * *"
+          cronExpression: "0 5 6-18/6 * * * *"
           enable: true
           argument: jd_fruit&jd_pet
     - timer: # 宠汪汪喂食# 宠汪汪# 摇钱树# 京东种豆得豆
         parameters:
           name: jd_joy_feedPets_jd_joy_jd_moneyTree_jd_plantBean
-          cronExpression: "0 15 */1 * * *"
+          cronExpression: "0 15 */1 * * * *"
           enable: true
           argument: jd_joy_feedPets&jd_joy&jd_moneyTree&jd_plantBean
     - timer: # 宠汪汪积分兑换奖品# 宠汪汪偷好友积分与狗
         parameters:
           name: jd_joy_reward_jd_joy_steal
-          cronExpression: "0 0 0-16/8 * * *"
+          cronExpression: "0 0 0-16/8 * * * *"
           enable: true
           argument: jd_joy_reward&jd_joy_steal
     - timer: # 京东全民开红包 # 进店领豆 # 取关京东店铺商品# 京东抽奖机
         parameters:
           name: jd_redPacket_jd_shop_jd_unsubscribe_jd_lotteryMachine
-          cronExpression: "0 10 0 * * *"
+          cronExpression: "0 10 0 * * * *"
           enable: true
           argument: jd_redPacket&jd_shop&jd_unsubscribe&jd_lotteryMachine
     - timer: # 京东天天加速
         parameters:
           name: jd_speed
-          cronExpression: "0 8 */3 * * *"
+          cronExpression: "0 8 */3 * * * *"
           enable: true
           argument: jd_speed
     - timer: # 东东超市
         parameters:
           name: jd_superMarket
-          cronExpression: "0 11 1-23/5 * * *"
+          cronExpression: "0 11 1-23/5 * * * *"
           enable: true
           argument: jd_superMarket
     - timer: # 京豆变动通知 # 京东排行榜
         parameters:
           name: jd_bean_change
-          cronExpression: "0 0 10 * * *"
+          cronExpression: "0 0 10 * * * *"
           enable: true
           argument: jd_bean_change&jd_rankingList
     - timer: # 金融养猪# 天天提鹅
         parameters:
           name: jd_pigPet_jd_daily_egg
-          cronExpression: "0 12 * * * *"
+          cronExpression: "0 12 * * * * *"
           enable: true
           argument: jd_pigPet&jd_daily_egg
   environment: #  环境变量


### PR DESCRIPTION
GitHub Action 部署到腾讯云函数完善
- 部署并自动配置定时任务，目前限制只能有10个定时任务触发，所以我自己看情况整理合并到了10个里面，有需要自行调整的，可以自己修改[ `serverless.yml`](https://github.com/lxk0301/jd_scripts/blob/master/serverless.yml) 里面的 `timer` 下面的配置。
- 云函数入口执行方式有三个，因为默认部署到了香港节点，所以默认执行方式也为远端获取GitHub的执行，如果需要调整，自己调整取消 [`index.js`](https://github.com/lxk0301/jd_scripts/blob/master/index.js) 里面的注释