### PR TITLE
增加配置服务器资源使用的限制

### DIFF
--- a/docker/example/default.yml
+++ b/docker/example/default.yml
@@ -1,5 +1,10 @@
 jd_scripts:
   image: akyakya/jd_scripts
+  deploy:
+    resources:
+      limits:
+        cpus: '0.2'
+        memory: 50M
   container_name: jd_scripts
   restart: always
   volumes:


### PR DESCRIPTION
默认单个容器最多使用20%的cpu和50M内存