### PR TITLE
添加任务延迟功能

### DIFF
--- a/docker/docker_entrypoint.sh
+++ b/docker/docker_entrypoint.sh
@@ -128,6 +128,11 @@ if [ $(grep -c "default_task.sh" $mergedListFile) -eq '0' ]; then
     echo "52 */1 * * * sh /scripts/docker/default_task.sh |ts >> /scripts/logs/default_task.log 2>&1" >>$mergedListFile
 fi
 
+if [ $RANDOM_DELAY_MAX -ge 1 ] then
+    echo "已设置随机延迟为 $RANDOM_DELAY_MAX , 设置延迟任务中... "
+    sh replaceNode_withRandomSleep.sh $mergedListFile
+fi
+
 echo "Load the latest crontab task file..."
 echo "加载最新的定时任务文件..."
 crontab $mergedListFile

--- a/docker/example/default.yml
+++ b/docker/example/default.yml
@@ -46,4 +46,7 @@ jd_scripts:
     # 例: JD_DEBUG=false
     - JD_DEBUG=
 
+    #如果设置了 RANDOM_DELAY_MAX ，则会启用随机延迟功能，延迟随机 1 - RANDOM_DELAY_MAX 秒。如果不设置此项，则不使用延迟。
+    #并不是所有的脚本都会被启用延迟，因为有一些脚本需要整点触发。延迟的目的有两个，1是降低抢占cpu资源几率，2是降低检查风险（主要是1）
+    - RANDOM_DELAY_MAX=
 

--- a/docker/replaceNode_withRandomSleep.sh
+++ b/docker/replaceNode_withRandomSleep.sh
@@ -1,0 +1,1 @@
+sed -i "/\(jd_bean_sign.js\|jd_blueCoin.js\|jd_club_lottery.js\)/!s/node/sleep \$((RANDOM % $RANDOM_DELAY_MAX)); node/g" $1


### PR DESCRIPTION
自动探测RANDOM_DELAY_MAX变量，如果设置了，则利用sed替换除必须固定时间运行的脚本以外的所有脚本任务的cron命令，在运行node前先运行sleep

创建了replaceNode_withRandomSleep.sh， 用于替换。替换的是最后生成的mergedListFile，所以没有负面影响。

目前默认不替换 jd_bean_sign.js，jd_blueCoin.js，jd_club_lottery.js 这三个任务，如果遗漏了，可以再添加。

替换后效果（注意哪些脚本被添加了sleep）：

![image](https://user-images.githubusercontent.com/75717694/102583439-9f17b780-40fc-11eb-9f76-a485c38d96f4.png)
