### PR TITLE
增加延迟功能。

### DIFF
--- a/docker/default_task.sh
+++ b/docker/default_task.sh
@@ -107,9 +107,9 @@ if [ $(grep -c "default_task.sh" $mergedListFile) -eq '0' ]; then
     echo "52 */1 * * * sh /scripts/docker/default_task.sh |ts >> /scripts/logs/default_task.log 2>&1" >>$mergedListFile
 fi
 
-if [ $RANDOM_DELAY_MAX -ge 1 ] then
+if [ $RANDOM_DELAY_MAX -ge 1 ]; then
     echo "已设置随机延迟为 $RANDOM_DELAY_MAX , 设置延迟任务中... "
-    sh replaceNode_withRandomSleep.sh $mergedListFile
+    source replaceNode_withRandomSleep.sh $mergedListFile
 fi
 
 echo "加载最新的定时任务文件..."

--- a/docker/default_task.sh
+++ b/docker/default_task.sh
@@ -107,5 +107,10 @@ if [ $(grep -c "default_task.sh" $mergedListFile) -eq '0' ]; then
     echo "52 */1 * * * sh /scripts/docker/default_task.sh |ts >> /scripts/logs/default_task.log 2>&1" >>$mergedListFile
 fi
 
+if [ $RANDOM_DELAY_MAX -ge 1 ] then
+    echo "已设置随机延迟为 $RANDOM_DELAY_MAX , 设置延迟任务中... "
+    sh replaceNode_withRandomSleep.sh $mergedListFile
+fi
+
 echo "加载最新的定时任务文件..."
 crontab $mergedListFile

--- a/docker/docker_entrypoint.sh
+++ b/docker/docker_entrypoint.sh
@@ -128,9 +128,9 @@ if [ $(grep -c "default_task.sh" $mergedListFile) -eq '0' ]; then
     echo "52 */1 * * * sh /scripts/docker/default_task.sh |ts >> /scripts/logs/default_task.log 2>&1" >>$mergedListFile
 fi
 
-if [ $RANDOM_DELAY_MAX -ge 1 ] then
+if [ $RANDOM_DELAY_MAX -ge 1 ]; then
     echo "已设置随机延迟为 $RANDOM_DELAY_MAX , 设置延迟任务中... "
-    sh replaceNode_withRandomSleep.sh $mergedListFile
+    source replaceNode_withRandomSleep.sh $mergedListFile
 fi
 
 echo "Load the latest crontab task file..."

--- a/docker/docker_entrypoint.sh
+++ b/docker/docker_entrypoint.sh
@@ -128,6 +128,11 @@ if [ $(grep -c "default_task.sh" $mergedListFile) -eq '0' ]; then
     echo "52 */1 * * * sh /scripts/docker/default_task.sh |ts >> /scripts/logs/default_task.log 2>&1" >>$mergedListFile
 fi
 
+if [ $RANDOM_DELAY_MAX -ge 1 ] then
+    echo "已设置随机延迟为 $RANDOM_DELAY_MAX , 设置延迟任务中... "
+    sh replaceNode_withRandomSleep.sh $mergedListFile
+fi
+
 echo "Load the latest crontab task file..."
 echo "加载最新的定时任务文件..."
 crontab $mergedListFile

--- a/docker/example/default.yml
+++ b/docker/example/default.yml
@@ -46,4 +46,7 @@ jd_scripts:
     # 例: JD_DEBUG=false
     - JD_DEBUG=
 
+    #如果设置了 RANDOM_DELAY_MAX ，则会启用随机延迟功能，延迟随机 1 - RANDOM_DELAY_MAX 秒。如果不设置此项，则不使用延迟。
+    #并不是所有的脚本都会被启用延迟，因为有一些脚本需要整点触发。延迟的目的有两个，1是降低抢占cpu资源几率，2是降低检查风险（主要是1）
+    - RANDOM_DELAY_MAX=
 

--- a/docker/example/default.yml
+++ b/docker/example/default.yml
@@ -46,7 +46,8 @@ jd_scripts:
     # 例: JD_DEBUG=false
     - JD_DEBUG=
 
-    #如果设置了 RANDOM_DELAY_MAX ，则会启用随机延迟功能，延迟随机 1 - RANDOM_DELAY_MAX 秒。如果不设置此项，则不使用延迟。
+    #如果设置了 RANDOM_DELAY_MAX ，则会启用随机延迟功能，延迟随机 0 到 RANDOM_DELAY_MAX-1 秒。如果不设置此项，则不使用延迟。
     #并不是所有的脚本都会被启用延迟，因为有一些脚本需要整点触发。延迟的目的有两个，1是降低抢占cpu资源几率，2是降低检查风险（主要是1）
+    #填写数字，单位为秒，比如写为 RANDOM_DELAY_MAX=30  就是随机产生0到29之间的一个秒数，执行延迟的意思。
     - RANDOM_DELAY_MAX=
 

--- a/docker/replaceNode_withRandomSleep.sh
+++ b/docker/replaceNode_withRandomSleep.sh
@@ -1,1 +1,1 @@
-sed -i "/\(jd_bean_sign.js\|jd_blueCoin.js\|jd_club_lottery.js\)/!s/node/sleep \$((RANDOM % \$RANDOM_DELAY_MAX)); node/g" $1
+sed -i "/\(jd_bean_sign.js\|jd_blueCoin.js\|jd_joy_reawrd.js\|jd_joy_steal.js\|jd_joy_feedPets.js\)/!s/node/sleep \$((RANDOM % \$RANDOM_DELAY_MAX)); node/g" $1

--- a/docker/replaceNode_withRandomSleep.sh
+++ b/docker/replaceNode_withRandomSleep.sh
@@ -1,0 +1,1 @@
+sed -i "/\(jd_bean_sign.js\|jd_blueCoin.js\|jd_club_lottery.js\)/!s/node/sleep \$((RANDOM % $RANDOM_DELAY_MAX)); node/g" $1

--- a/docker/replaceNode_withRandomSleep.sh
+++ b/docker/replaceNode_withRandomSleep.sh
@@ -1,1 +1,1 @@
-sed -i "/\(jd_bean_sign.js\|jd_blueCoin.js\|jd_club_lottery.js\)/!s/node/sleep \$((RANDOM % $RANDOM_DELAY_MAX)); node/g" $1
+sed -i "/\(jd_bean_sign.js\|jd_blueCoin.js\|jd_club_lottery.js\)/!s/node/sleep \$((RANDOM % \$RANDOM_DELAY_MAX)); node/g" $1


### PR DESCRIPTION
延迟的目的有2，1是防止突然大量脚本同时运行抢占资源，2是可以降低审查概率。主要是1.

默认不添加延迟，我在default.yml里添加了如下：

```
 #如果设置了 RANDOM_DELAY_MAX ，则会启用随机延迟功能，延迟随机 1 - RANDOM_DELAY_MAX 秒。如果不设置此项，则不使用延迟。
    #并不是所有的脚本都会被启用延迟，因为有一些脚本需要整点触发。延迟的目的有两个，1是降低抢占cpu资源几率，2是降低检查风险（主要是1）
    - RANDOM_DELAY_MAX=
    - 
```

在default_task.sh和 docker_entrypoint.sh里添加了如下：

```
if [ $RANDOM_DELAY_MAX -ge 1 ] then
    echo "已设置随机延迟为 $RANDOM_DELAY_MAX , 设置延迟任务中... "
    sh replaceNode_withRandomSleep.sh $mergedListFile
fi

```
然后替换脚本如下：
`
sed -i "/\(jd_bean_sign.js\|jd_blueCoin.js\|jd_club_lottery.js\)/!s/node/sleep \$((RANDOM % \$RANDOM_DELAY_MAX)); node/g" $1
`

这个替换语句里面有个叹号，如果不单放进文件的话，执行会被bash转义为历史事件，导致运行错误。所以只能单创建个脚本。


可以看替换脚本里，我 对 jd_bean_sign，jd_blueCoin，jd_club_lottery 不设延迟。如有更多脚本不能设延迟，可以告诉我我再加，或者是merge了之后你们以后再加。

（更新：已防止 jd_joy_reawrd, jd_joy_steal, jd_joy_feedPets进行延迟，已使得jd_club_lottery 可延迟）

替换效果：

![image](https://user-images.githubusercontent.com/75717694/102585303-14d15280-4100-11eb-8c6c-db05bf7294ec.png)
