### PR TITLE
提取互助码bug修复 ，延迟任务处理增加提示

### DIFF
--- a/docker/default_task.sh
+++ b/docker/default_task.sh
@@ -107,9 +107,13 @@ if [ $(grep -c "default_task.sh" $mergedListFile) -eq '0' ]; then
     echo "52 */1 * * * sh /scripts/docker/default_task.sh |ts >> /scripts/logs/default_task.log 2>&1" >>$mergedListFile
 fi
 
-if [ $RANDOM_DELAY_MAX -ge 1 ]; then
-    echo "已设置随机延迟为 $RANDOM_DELAY_MAX , 设置延迟任务中... "
-    sed -i "/\(jd_bean_sign.js\|jd_blueCoin.js\|jd_joy_reward.js\|jd_joy_steal.js\|jd_joy_feedPets.js\)/!s/node/sleep \$((RANDOM % \$RANDOM_DELAY_MAX)); node/g" $mergedListFile
+if [ $RANDOM_DELAY_MAX ];then
+    if [ $RANDOM_DELAY_MAX -ge 1 ]; then
+        echo "已设置随机延迟为 $RANDOM_DELAY_MAX , 设置延迟任务中... "
+        sed -i "/\(jd_bean_sign.js\|jd_blueCoin.js\|jd_joy_reward.js\|jd_joy_steal.js\|jd_joy_feedPets.js\)/!s/node/sleep \$((RANDOM % \$RANDOM_DELAY_MAX)); node/g" $mergedListFile
+    fi
+else
+    echo "未配置随即延迟对应的环境变量，故不设置延迟任务"
 fi
 
 echo "加载最新的定时任务文件..."

--- a/docker/proc_file.sh
+++ b/docker/proc_file.sh
@@ -14,22 +14,22 @@ jdpet="${logdDir}/jd_pet.log"
 
 echo -e >$sharecodeFile
 
-sed -n '/京东赚赚好友互助码】.*/'p $jdzzFile | awk '{print $1}' | sort | uniq >>$sharecodeFile
+sed -n '/京东赚赚好友互助码】.*/'p $jdzzFile | awk '{print $4,$5}' | sort | uniq >>$sharecodeFile
 echo "提取京东赚赚助力码完成"
 
-sed -n '/东东工厂好友互助码】.*/'p $jdfactoryFile | awk '{print $1}' | sort | uniq >>$sharecodeFile
+sed -n '/东东工厂好友互助码】.*/'p $jdfactoryFile | awk '{print $4,$5}' | sort | uniq >>$sharecodeFile
 echo "提取东东工厂助力码完成"
 
-sed -n '/京喜工厂好友互助码.*/'p $jxFactoryFile | awk '{print $1}' | sort | uniq >>$sharecodeFile
+sed -n '/京喜工厂好友互助码.*/'p $jxFactoryFile | awk '{print $4,$5}' | sort | uniq >>$sharecodeFile
 echo "提取京喜工厂助力码完成"
 
-sed -n '/京东种豆得豆好友互助码】.*/'p $plantBean | awk '{print $1}' | sort | uniq >>$sharecodeFile
+sed -n '/京东种豆得豆好友互助码】.*/'p $plantBean | awk '{print $4,$5}' | sort | uniq >>$sharecodeFile
 echo "提取京东种豆助力码完成"
 
-sed -n '/东东农场好友互助码】.*/'p $jdfruit | awk '{print $1}' | sort | uniq >>$sharecodeFile
+sed -n '/东东农场好友互助码】.*/'p $jdfruit | awk '{print $4,$5}' | sort | uniq >>$sharecodeFile
 echo "提取京东农场助力码完成"
 
-sed -n '/东东萌宠好友互助码】.*/'p $jdpet | awk '{print $1}' | sort | uniq >>$sharecodeFile
+sed -n '/东东萌宠好友互助码】.*/'p $jdpet | awk '{print $4,$5}' | sort | uniq >>$sharecodeFile
 echo "提取东东萌宠助力码完成"
 
 echo "==========================================================================="


### PR DESCRIPTION
提取互助码bug修复 因为之前测试时候日志输出未设置ts，所以$1没问题，默认所有日志有|ts输出，所以需要改取 $4,$5也取是担心中间会有多的空格影响分列

如果RANDOM_DELAY_MAX未配置执行提示sh: 1: unknown operand，增一个判断提示
https://github.com/lxk0301/jd_scripts/pull/372