### PR TITLE
企业微信消息修改为图文消息（文章）

### DIFF
--- a/sendNotify.js
+++ b/sendNotify.js
@@ -49,7 +49,7 @@ let DD_BOT_SECRET = '';
 let QYWX_KEY = '';
 
 // =======================================企业微信应用消息通知设置区域===========================================
-//此处填你企业微信应用消息的 值(详见文档 https://work.weixin.qq.com/api/doc/90000/90135/90236)，依次填上corpid的值,corpsecret的值,touser的值,agentid的值，注意用,号隔开，例如：wwcff56746d9adwers,B-791548lnzXBE6_BWfxdf3kSTMJr9vFEPKAbh6WERQ,mingcheng,1000001
+//此处填你企业微信应用消息的 值(详见文档 https://work.weixin.qq.com/api/doc/90000/90135/90236)，依次填上corpid的值,corpsecret的值,touser的值,agentid的值，素材库图片id（见https://work.weixin.qq.com/api/doc/90000/90135/90253） 注意用,号隔开，例如：wwcff56746d9adwers,B-791548lnzXBE6_BWfxdf3kSTMJr9vFEPKAbh6WERQ,mingcheng,1000001,2COXgjH2UIfERF2zxrtUOKgQ9XklUqMdGSWLBoW_lSDAdafat
 //注：此处设置github action用户填写到Settings-Secrets里面(Name输入QYWX_AM)
 let QYWX_AM = '';
 
@@ -438,12 +438,18 @@ function qywxamNotify(text, desp) {
 	      json: {
 	        touser:`${QYWX_AM_AY[2]}`,
 	        agentid:`${QYWX_AM_AY[3]}`,
-	        msgtype: 'textcard',
-	        textcard: {
+	        msgtype: 'mpnews',
+	        mpnews: {
+                  articles: [
+                  {
 	          title: `${text}`,
-	          description: `${desp}`,
-	          url: '127.0.0.1',
-	          btntxt: '更多'
+                  thumb_media_id: `${QYWX_AM_AY[4]}`,  
+                  author : `智能助手` ,
+                  content_source_url: ``,
+                  content : `${desp}`,  //暂时直接设置成了desp
+                  digest: `${desp}`
+                  }
+                  ]
 	        },
 	        safe:'0',
 	      },


### PR DESCRIPTION
- 改成了图文消息模式，原本的卡片信息只能显示512字节，并且看不了详情。
- 图文消息，可以设置图片和文章，并且描述也一样是512字节限制。但是可以点进去看文章详情。
- thumb_media_id  需要在管理工具-素材库 把图片上传企业微信素材库之后点击外链就能查询。链接内会有mediaid=xxxxx
直接传是永久id，必须设置。文档 https://work.weixin.qq.com/api/doc/90000/90135/90253 
- 文章内容暂时用的 ${desp} ，测试用marked.js 转换markdown为HTML之后也不会换行 直接把头尾换成了html的换行（估计是marked.js检测换行符的问题），我也懒得自己写方法希望来个大神补上。