### PR TITLE
修复企业微信 应用消息文章中的换行缺失

### DIFF
--- a/sendNotify.js
+++ b/sendNotify.js
@@ -49,7 +49,7 @@ let DD_BOT_SECRET = '';
 let QYWX_KEY = '';
 
 // =======================================企业微信应用消息通知设置区域===========================================
-//此处填你企业微信应用消息的 值(详见文档 https://work.weixin.qq.com/api/doc/90000/90135/90236)，依次填上corpid的值,corpsecret的值,touser的值,agentid的值，素材库图片id（见https://work.weixin.qq.com/api/doc/90000/90135/90253） 注意用,号隔开，例如：wwcff56746d9adwers,B-791548lnzXBE6_BWfxdf3kSTMJr9vFEPKAbh6WERQ,mingcheng,1000001,2COXgjH2UIfERF2zxrtUOKgQ9XklUqMdGSWLBoW_lSDAdafat
+//此处填你企业微信应用消息的 值(详见文档 https://work.weixin.qq.com/api/doc/90000/90135/90236)，依次填上corpid的值,corpsecret的值,touser的值,agentid的值，素材库图片id（见https://github.com/lxk0301/jd_scripts/issues/519) 注意用,号隔开，例如：wwcff56746d9adwers,B-791548lnzXBE6_BWfxdf3kSTMJr9vFEPKAbh6WERQ,mingcheng,1000001,2COXgjH2UIfERF2zxrtUOKgQ9XklUqMdGSWLBoW_lSDAdafat
 //注：此处设置github action用户填写到Settings-Secrets里面(Name输入QYWX_AM)
 let QYWX_AM = '';
 
@@ -430,7 +430,8 @@ function qywxamNotify(text, desp) {
 	        'Content-Type': 'application/json',
 	      },
 	    };
-	  $.post(options_accesstoken, (err, resp, data) => {  
+	  $.post(options_accesstoken, (err, resp, data) => {
+      html=desp.replace(/\n/g,"<br/>")	  
       var json = JSON.parse(data);
       accesstoken = json.access_token;
 		const options = {
@@ -446,7 +447,7 @@ function qywxamNotify(text, desp) {
                   thumb_media_id: `${QYWX_AM_AY[4]}`,  
                   author : `智能助手` ,
                   content_source_url: ``,
-                  content : `${desp}`,  //暂时直接设置成了desp
+                  content : `${html}`, 
                   digest: `${desp}`
                   }
                   ]


### PR DESCRIPTION
- 修复企业微信 应用消息图文消息推送中换行缺失的问题
- 简单的替换了换行符，以后可以按照需求增加css等样式。
- 更换了图片id的issues说明链接